### PR TITLE
Disable source tracking on PR validation for faster deployment

### DIFF
--- a/.github/workflows/pr.validation.yml
+++ b/.github/workflows/pr.validation.yml
@@ -154,6 +154,9 @@ jobs:
           node-version: 20
       - run: npm ci --prefer-offline --no-audit # force offline installs for quicker run
 
+      - name: Deactivate Source Tracking
+        run: sf org disable tracking --target-org ${{ needs.scratch-org.outputs.username }}
+
       # Run Pre-Deploy Steps
       - name: Run Pre-Deploy Steps
         run: npx ssdx resource --pre-deploy --target-org ${{ needs.scratch-org.outputs.username }} --show-output --ci


### PR DESCRIPTION
Example (big) deployment from Internal SF Project
<img width="744" height="925" alt="image" src="https://github.com/user-attachments/assets/7580fa93-2a85-4405-a059-d1d5cee3c31d" />