### PR TITLE
[FKP-999] fix to retry functionality

### DIFF
--- a/.github/workflows/pr.validation.yml
+++ b/.github/workflows/pr.validation.yml
@@ -27,7 +27,7 @@ jobs:
       pull-requests: write
       actions: write
     uses: ./.github/workflows/subflow.scratch_org.yml
-    if: contains(github.triggering_actor, '[bot]') == false || github.triggering_actor == 'github-bot[bot]' #! Skip if the actor is the custom bot. Allows the standard github-bot[bot] to trigger validation when running /retry
+    if: contains(github.triggering_actor, '[bot]') == false || github.triggering_actor == 'github-actions[bot]' #! Skip if the actor is the custom bot. Allows the standard github-actions[bot] to trigger validation when running /retry
     secrets: inherit
     with:
       alwaysGetScratchOrg: true


### PR DESCRIPTION
standard bot is called "github-actions[bot]", not "github-bot[bot]"

# Tips

-   TITTEL
    -   Tittelen blir automatisk generert for deg, så skriv din ønskede tittel UTEN `SPESP-123`, osv
-   BESRKIVELSE
    -   Beskrivelsen (denne boksen) blir automatisk overskrevet med Jira-beskrivelsen
-   CODE REVIEW
    -   Unngå Code Review Post? Lag PR som draft eller legg på label `disable-review-post`
-   SNAPSHOTS
    -   Validering uten Snapshots? Legg på label `disable-snapshot`
